### PR TITLE
Reduced Schedule

### DIFF
--- a/.github/workflows/update-lein.yml
+++ b/.github/workflows/update-lein.yml
@@ -1,7 +1,7 @@
 name: Update lein
 "on":
     schedule:
-        - cron: 30 * * * *
+        - cron: 0 5 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:


### PR DESCRIPTION
Previously, the regularly scheduled builds exhausted the free tier of GitHub actions in some orgs.  This change reduces the number of hours and number of days that these scheduled events will run.