### PR TITLE
Provides jvm-application-package instead of jvm-application

### DIFF
--- a/lein/detect.go
+++ b/lein/detect.go
@@ -24,6 +24,12 @@ import (
 	"github.com/buildpacks/libcnb"
 )
 
+const (
+	PlanEntryLein                  = "lein"
+	PlanEntryJVMApplicationPackage = "jvm-application-package"
+	PlanEntryJDK                   = "jdk"
+)
+
 type Detect struct{}
 
 func (Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error) {
@@ -40,12 +46,12 @@ func (Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error) 
 		Plans: []libcnb.BuildPlan{
 			{
 				Provides: []libcnb.BuildPlanProvide{
-					{Name: "lein"},
-					{Name: "jvm-application"},
+					{Name: PlanEntryLein},
+					{Name: PlanEntryJVMApplicationPackage},
 				},
 				Requires: []libcnb.BuildPlanRequire{
-					{Name: "lein"},
-					{Name: "jdk"},
+					{Name: PlanEntryLein},
+					{Name: PlanEntryJDK},
 				},
 			},
 		},

--- a/lein/detect_test.go
+++ b/lein/detect_test.go
@@ -61,7 +61,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 				{
 					Provides: []libcnb.BuildPlanProvide{
 						{Name: "lein"},
-						{Name: "jvm-application"},
+						{Name: "jvm-application-package"},
 					},
 					Requires: []libcnb.BuildPlanRequire{
 						{Name: "lein"},


### PR DESCRIPTION
Changes name of provided plan entry to draw a distinction between a runnable JVM application (mostly process types) contributed by buildpacks like `paketo-buildpacks/executable-jar` and the packaged bytecode required as input to those buildpacks, provided by build system buildpacks like `paketo-buildpacks/leiningen`.
