### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Paketo Buildpack for Leiningen
 
-The Paketo Leiningen Buildpack is a Cloud Native Buildpack that builds Leiningen-based applications from source.
+The Paketo Buildpack for Leiningen is a Cloud Native Buildpack that builds Leiningen-based applications from source.
 
 ## Behavior
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/leiningen"
   id = "paketo-buildpacks/leiningen"
   keywords = ["java", "leiningen", "build-system"]
-  name = "Paketo Leiningen Buildpack"
+  name = "Paketo Buildpack for Leiningen"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/vnd.syft+json"]
   version = "{{.version}}"
 


### PR DESCRIPTION
Renames 'Paketo Leiningen Buildpack' to 'Paketo Buildpack for Leiningen'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
