### PR TITLE
Add detection logging messages at info level

### DIFF
--- a/lein/detect.go
+++ b/lein/detect.go
@@ -18,6 +18,7 @@ package lein
 
 import (
 	"fmt"
+	"github.com/paketo-buildpacks/libpak/bard"
 	"os"
 	"path/filepath"
 
@@ -34,9 +35,11 @@ const (
 type Detect struct{}
 
 func (Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error) {
+	l := bard.NewLogger(os.Stdout)
 	file := filepath.Join(context.Application.Path, "project.clj")
 	_, err := os.Stat(file)
 	if os.IsNotExist(err) {
+		l.Logger.Infof("SKIPPED: project.clj could not be found in %s", file)
 		return libcnb.DetectResult{Pass: false}, nil
 	} else if err != nil {
 		return libcnb.DetectResult{}, fmt.Errorf("unable to determine if %s exists\n%w", file, err)


### PR DESCRIPTION
*Log messages were checked during testing*

```
=== RUN   TestUnit/lein/Detect/fails_without_project.clj
SKIPPED: project.clj could not be found in /var/folders/rl/bdnmjrz16bz1wn7dblwvxmpc0000gq/T/lein3453067255/project.clj
```


## Summary
This PR adds additional logging when Detect returns false for this buildpack. This is to provide more information about why the detection failed for this buildpack when verbose/debug logging is enabled. 

As of lifecycle v1.16.0, if the detect phase fails as a whole, log messages are printed at info level by default, without the need for the verbose flag.

## Use Cases
A `pack build` command with the `--verbose` flag set will show these log statement if detection fails. If Detect succeeds, the output is not shown unless `--verbose` is set.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).